### PR TITLE
fix typo in basicauth tutorial

### DIFF
--- a/src/render/tutorials/api-gateway-security-basic-auth/2_0.html.md
+++ b/src/render/tutorials/api-gateway-security-basic-auth/2_0.html.md
@@ -55,7 +55,7 @@ paths:
         '200':
           description: Hello World API protected with Basic Auth
         '401':
-          description: Anauthorized access
+          description: Unauthorized access
 ```
 
 Notice different responses defined for the secured endpoint. For more info on different responses see [this tutorial](/tutorials/openapi-and-swagger-ui/2_0/).


### PR DESCRIPTION
Another typo fix ;)
---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
