### PR TITLE
Knotx/knotx-fragments#95 Remove knotx-data-bridge repository reference

### DIFF
--- a/src/render/documentation.html
+++ b/src/render/documentation.html
@@ -84,7 +84,8 @@ order: 5
         with distributed systems stability patterns such as a circuit breaker to handle different
         kinds of network failures. Thanks to those build-in mechanisms developers can focus more on
         delivering business logic and make the solution ready to handle any unexpected integration
-        problems.
+        problems. The repository also provides HTTP Action that connects to the external WEB
+        endpoint that responds with JSON.
       </p>
     </div>
 
@@ -123,19 +124,6 @@ order: 5
       <p>The repository connector provides a template from external repositories, such as CMS or
         file
         system.</p>
-    </div>
-
-    <div class="col-sm-12">
-      <h3>knotx-data-bridge
-        <a class="btn btn-lg"
-           href="https://github.com/Knotx/knotx-data-bridge#knotx-data-bridge"
-           role="button" target="_blank"><span class="fa fa-book"></span> Explore the docs</a>
-      </h3>
-      <p>Data Bridge is an integration module that enriches Fragments with the data from external
-        sources.
-        It comes with HTTP Action that connects to the external WEB endpoint that responds with
-        JSON.
-      </p>
     </div>
 
     <div class="col-sm-12">


### PR DESCRIPTION
Removes reference to knotx-data-bridge from documentation

## Motivation and Context
Knotx/knotx-fragments#95 Remove knotx-data-bridge repository reference

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
